### PR TITLE
hide message when adding cscope database at start up

### DIFF
--- a/plugin/cscope_maps.vim
+++ b/plugin/cscope_maps.vim
@@ -33,6 +33,9 @@ if has("cscope")
     " if you want the reverse search order.
     set csto=0
 
+    " hide msg when adding cscope database at start
+    set nocscopeverbose
+
     " Find and add a cscope file. Either from CSCOPE_DB or by searching for it
     " recursively starting in the CWD and going up to /
     if $CSCOPE_DB != ""


### PR DESCRIPTION
It seems sometimes 'cscopeverbose' is set and vim shows a warning message when adding cscope database at start up.
This PR set 'nocscopeverbose' right before adding database to ensure that message is not shown.