### PR TITLE
Hide message when adding cscope database at start up.

### DIFF
--- a/plugin/cscope_maps.vim
+++ b/plugin/cscope_maps.vim
@@ -34,6 +34,9 @@ if has("cscope")
     " if you want the reverse search order.
     set csto=0
 
+    " hide msg when adding cscope database at start
+    set nocscopeverbose
+
     " Find and add a cscope file. Either from CSCOPE_DB or by searching for it
     " recursively starting in the CWD and going up to /
     if $CSCOPE_DB != ""


### PR DESCRIPTION
Some Linux distributions (such as Fedora) includes vim script /etc/vimrc
(or equivalent) which auto add cscope database from $CSCOPE_DB or from
current directory, and enable `cscopeverbose`. When this plugin tries to add
cscope database, warning message is shown and requires user to confirm
by pressing ENTER. To avoid this, `set nocscopeverbose` before trying to
add cscope database.